### PR TITLE
feat: implement functional rate limiting for API security

### DIFF
--- a/pages/api/gemini/fetch.js
+++ b/pages/api/gemini/fetch.js
@@ -1,7 +1,11 @@
 import { sendGeminiRequest } from '@derhuerst/gemini/client.js';
-import { isUrlSafe } from '../../../utils/security';
+import { isUrlSafe, applyRateLimit } from '../../../utils/security';
 
 export default async function handler(req, res) {
+  if (!applyRateLimit(req, res)) {
+    return;
+  }
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }


### PR DESCRIPTION
## Summary
- Implement working rate limiting functionality (100 requests per 15 minutes per IP)
- Revert overly complex DNS resolution approach back to simple hostname blocking
- Add automatic cleanup of expired rate limit records to prevent memory leaks

## Test plan
- [x] Test rate limiting by making > 100 requests from same IP
- [x] Verify 429 status returned when limit exceeded
- [x] Confirm cleanup runs every 5 minutes
- [x] Verify security checks still block private IPs and sensitive ports

🤖 Generated with [Claude Code](https://claude.ai/code)